### PR TITLE
Handle deprecated OperatorWhitelistUpdated event 

### DIFF
--- a/abis/SSVNetwork.json
+++ b/abis/SSVNetwork.json
@@ -814,6 +814,25 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "uint64",
+        "name": "operatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "whitelisted",
+        "type": "address"
+      }
+    ],
+    "name": "OperatorWhitelistUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "uint64[]",
         "name": "operatorIds",
         "type": "uint64[]"

--- a/abis/SSVNetwork.json
+++ b/abis/SSVNetwork.json
@@ -813,7 +813,7 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "uint64",
         "name": "operatorId",
         "type": "uint64"

--- a/generated/SSVNetwork/SSVNetwork.ts
+++ b/generated/SSVNetwork/SSVNetwork.ts
@@ -584,6 +584,28 @@ export class OperatorMaximumFeeUpdated__Params {
   }
 }
 
+export class OperatorWhitelistUpdated extends ethereum.Event {
+  get params(): OperatorWhitelistUpdated__Params {
+    return new OperatorWhitelistUpdated__Params(this);
+  }
+}
+
+export class OperatorWhitelistUpdated__Params {
+  _event: OperatorWhitelistUpdated;
+
+  constructor(event: OperatorWhitelistUpdated) {
+    this._event = event;
+  }
+
+  get operatorId(): BigInt {
+    return this._event.parameters[0].value.toBigInt();
+  }
+
+  get whitelisted(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+}
+
 export class OperatorMultipleWhitelistRemoved extends ethereum.Event {
   get params(): OperatorMultipleWhitelistRemoved__Params {
     return new OperatorMultipleWhitelistRemoved__Params(this);

--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -3075,6 +3075,118 @@ export class OperatorRemoved extends Entity {
   }
 }
 
+export class OperatorWhitelistUpdated extends Entity {
+  constructor(id: Bytes) {
+    super();
+    this.set("id", Value.fromBytes(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(
+      id != null,
+      "Cannot save OperatorWhitelistUpdated entity without an ID",
+    );
+    if (id) {
+      assert(
+        id.kind == ValueKind.BYTES,
+        `Entities of type OperatorWhitelistUpdated must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`,
+      );
+      store.set("OperatorWhitelistUpdated", id.toBytes().toHexString(), this);
+    }
+  }
+
+  static loadInBlock(id: Bytes): OperatorWhitelistUpdated | null {
+    return changetype<OperatorWhitelistUpdated | null>(
+      store.get_in_block("OperatorWhitelistUpdated", id.toHexString()),
+    );
+  }
+
+  static load(id: Bytes): OperatorWhitelistUpdated | null {
+    return changetype<OperatorWhitelistUpdated | null>(
+      store.get("OperatorWhitelistUpdated", id.toHexString()),
+    );
+  }
+
+  get id(): Bytes {
+    let value = this.get("id");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
+  }
+
+  get operatorId(): BigInt {
+    let value = this.get("operatorId");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set operatorId(value: BigInt) {
+    this.set("operatorId", Value.fromBigInt(value));
+  }
+
+  get whitelisted(): Bytes {
+    let value = this.get("whitelisted");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set whitelisted(value: Bytes) {
+    this.set("whitelisted", Value.fromBytes(value));
+  }
+
+  get blockNumber(): BigInt {
+    let value = this.get("blockNumber");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
+  }
+
+  get blockTimestamp(): BigInt {
+    let value = this.get("blockTimestamp");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set blockTimestamp(value: BigInt) {
+    this.set("blockTimestamp", Value.fromBigInt(value));
+  }
+
+  get transactionHash(): Bytes {
+    let value = this.get("transactionHash");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set transactionHash(value: Bytes) {
+    this.set("transactionHash", Value.fromBytes(value));
+  }
+}
+
 export class OperatorMultipleWhitelistUpdated extends Entity {
   constructor(id: Bytes) {
     super();

--- a/schema.graphql
+++ b/schema.graphql
@@ -257,6 +257,15 @@ type OperatorRemoved @entity(immutable: true) {
   transactionHash: Bytes!
 }
 
+type OperatorWhitelistUpdated @entity(immutable: true) {
+  id: Bytes!
+  operatorId: BigInt! # uint64
+  whitelisted: Bytes! # address
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
 type OperatorMultipleWhitelistUpdated @entity(immutable: true) {
   id: Bytes!
   operatorIds: [BigInt!]! # uint64[]

--- a/src/ssv-network.ts
+++ b/src/ssv-network.ts
@@ -19,6 +19,7 @@ import {
   OperatorMaximumFeeUpdated as OperatorMaximumFeeUpdatedEvent,
   OperatorRemoved as OperatorRemovedEvent,
   OperatorWhitelistingContractUpdated as OperatorWhitelistingContractUpdatedEvent,
+  OperatorWhitelistUpdated as OperatorWhitelistUpdatedEvent,
   OperatorMultipleWhitelistRemoved as OperatorMultipleWhitelistRemovedEvent,
   OperatorMultipleWhitelistUpdated as OperatorMultipleWhitelistUpdatedEvent,
   OperatorPrivacyStatusUpdated as OperatorPrivacyStatusUpdatedEvent,
@@ -49,6 +50,7 @@ import {
   OperatorFeeIncreaseLimitUpdated,
   OperatorMaximumFeeUpdated,
   OperatorRemoved,
+  OperatorWhitelistUpdated,
   OperatorMultipleWhitelistUpdated,
   OperatorMultipleWhitelistRemoved,
   OperatorWhitelistingContractUpdated,
@@ -846,6 +848,48 @@ export function handleOperatorRemoved(event: OperatorRemovedEvent): void {
   else {
     operator.operatorId = event.params.operatorId
     operator.active = false
+    operator.lastUpdateBlockNumber = event.block.number
+    operator.lastUpdateBlockTimestamp = event.block.timestamp
+    operator.lastUpdateTransactionHash = event.transaction.hash
+    operator.save()
+  }
+}
+
+export function handleOperatorWhitelistUpdated(
+  event: OperatorWhitelistUpdatedEvent
+): void {
+  let entity = new OperatorWhitelistUpdated(
+    event.transaction.hash.concatI32(event.logIndex.toI32())
+  )
+  entity.operatorId = event.params.operatorId
+  entity.whitelisted = event.params.whitelisted
+
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+
+  entity.save()
+
+  let whitelisted = Account.load(event.params.whitelisted)
+  if (!whitelisted){
+    log.info(`Adding new whitelisted address ${event.params.whitelisted.toHexString()} to Operator ${event.params.operatorId}, this is a new Account`, [])
+    whitelisted = new Account(event.params.whitelisted)
+    whitelisted.nonce = BigInt.zero()
+    whitelisted.save()
+  }
+
+  let operatorId = event.params.operatorId.toString()
+  let operator = Operator.load(operatorId) 
+  if (!operator) {
+    log.error(`Executing fees change for Operator ${event.params.operatorId}, but it does not exist on the database`, [])
+    log.error(`Could not create ${operatorId} on the database, because of missing owner, publicKey and fee information`, [])
+  }
+  else {
+    if (!operator.whitelisted) {
+      operator.whitelisted = []
+    }
+    operator.operatorId = event.params.operatorId
+    operator.whitelisted.push( whitelisted.id)
     operator.lastUpdateBlockNumber = event.block.number
     operator.lastUpdateBlockTimestamp = event.block.timestamp
     operator.lastUpdateTransactionHash = event.transaction.hash

--- a/src/ssv-network.ts
+++ b/src/ssv-network.ts
@@ -691,7 +691,7 @@ export function handleOperatorAdded(event: OperatorAddedEvent): void {
     operator.previousFee = event.params.fee
     operator.whitelisted = []
     operator.isPrivate = false
-    operator.whitelistedContract = new Address(0x0000000000000000000000000000000000000000)
+    operator.whitelistedContract = Address.fromString('0x0000000000000000000000000000000000000000');
     operator.totalWithdrawn = BigInt.zero()
   }
   
@@ -877,7 +877,6 @@ export function handleOperatorWhitelistUpdated(
     whitelisted.nonce = BigInt.zero()
     whitelisted.save()
   }
-
   let operatorId = event.params.operatorId.toString()
   let operator = Operator.load(operatorId) 
   if (!operator) {
@@ -889,7 +888,7 @@ export function handleOperatorWhitelistUpdated(
       operator.whitelisted = []
     }
     operator.operatorId = event.params.operatorId
-    operator.whitelisted.push( whitelisted.id)
+    operator.whitelisted = [whitelisted.id]
     operator.lastUpdateBlockNumber = event.block.number
     operator.lastUpdateBlockTimestamp = event.block.timestamp
     operator.lastUpdateTransactionHash = event.transaction.hash

--- a/src/ssv-network.ts
+++ b/src/ssv-network.ts
@@ -888,7 +888,13 @@ export function handleOperatorWhitelistUpdated(
       operator.whitelisted = []
     }
     operator.operatorId = event.params.operatorId
-    operator.whitelisted = [whitelisted.id]
+    if (event.params.whitelisted == Address.fromString('0x0000000000000000000000000000000000000000')){
+      operator.isPrivate = false;
+      operator.whitelisted = [];
+    } else {
+      operator.isPrivate = true;
+      operator.whitelisted = [whitelisted.id]
+    }
     operator.lastUpdateBlockNumber = event.block.number
     operator.lastUpdateBlockTimestamp = event.block.timestamp
     operator.lastUpdateTransactionHash = event.transaction.hash

--- a/src/ssv-network.ts
+++ b/src/ssv-network.ts
@@ -871,7 +871,7 @@ export function handleOperatorWhitelistUpdated(
   entity.save()
 
   let whitelisted = Account.load(event.params.whitelisted)
-  if (!whitelisted){
+  if (!whitelisted && (event.params.whitelisted != Address.fromString('0x0000000000000000000000000000000000000000'))){
     log.info(`Adding new whitelisted address ${event.params.whitelisted.toHexString()} to Operator ${event.params.operatorId}, this is a new Account`, [])
     whitelisted = new Account(event.params.whitelisted)
     whitelisted.nonce = BigInt.zero()
@@ -884,9 +884,7 @@ export function handleOperatorWhitelistUpdated(
     log.error(`Could not create ${operatorId} on the database, because of missing owner, publicKey and fee information`, [])
   }
   else {
-    if (!operator.whitelisted) {
-      operator.whitelisted = []
-    }
+    if (whitelisted) {
     operator.operatorId = event.params.operatorId
     if (event.params.whitelisted == Address.fromString('0x0000000000000000000000000000000000000000')){
       operator.isPrivate = false;
@@ -895,6 +893,7 @@ export function handleOperatorWhitelistUpdated(
       operator.isPrivate = true;
       operator.whitelisted = [whitelisted.id]
     }
+  }
     operator.lastUpdateBlockNumber = event.block.number
     operator.lastUpdateBlockTimestamp = event.block.timestamp
     operator.lastUpdateTransactionHash = event.transaction.hash

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     source:
       address: "0x38A4794cCEd47d3baf7370CcC43B560D3a1beEFA"
       abi: SSVNetwork
-      startBlock: 181611
+      startBlock: 1653200
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -50,6 +50,7 @@ dataSources:
         - OperatorMaximumFeeUpdated
         - OperatorRemoved
         - OperatorWithdrawn
+        - OperatorWhitelistUpdated
         - OperatorMultipleWhitelistRemoved
         - OperatorMultipleWhitelistUpdated
         - OperatorWhitelistingContractUpdated
@@ -115,6 +116,8 @@ dataSources:
           handler: handleOperatorMaximumFeeUpdated
         - event: OperatorRemoved(indexed uint64)
           handler: handleOperatorRemoved
+        - event: OperatorWhitelistUpdated(uint64,address)
+          handler: handleOperatorWhitelistUpdated
         - event: OperatorMultipleWhitelistUpdated(uint64[],address[])
           handler: handleOperatorMultipleWhitelistUpdated
         - event: OperatorMultipleWhitelistRemoved(uint64[],address[])

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     source:
       address: "0x38A4794cCEd47d3baf7370CcC43B560D3a1beEFA"
       abi: SSVNetwork
-      startBlock: 1653200
+      startBlock: 181611
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -116,7 +116,7 @@ dataSources:
           handler: handleOperatorMaximumFeeUpdated
         - event: OperatorRemoved(indexed uint64)
           handler: handleOperatorRemoved
-        - event: OperatorWhitelistUpdated(uint64,address)
+        - event: OperatorWhitelistUpdated(indexed uint64,address)
           handler: handleOperatorWhitelistUpdated
         - event: OperatorMultipleWhitelistUpdated(uint64[],address[])
           handler: handleOperatorMultipleWhitelistUpdated


### PR DESCRIPTION
When adding new changes to accommodate the new multi-operator events, the old event was incorrectly removed from the subgraph, here we're adding it back in. 

Tested on my local setup with operator 35 which saw these issues, also ensured the new events are still stored correctly. 

<img width="864" alt="image" src="https://github.com/RaekwonIII/ssv-subgraph/assets/45994626/2f97198c-86b9-4075-bcde-626182d41071">

https://thegraph.com/studio/subgraph/taylor-ssv-test/playground