### PR TITLE
Update fee to zero on operator removed

### DIFF
--- a/src/ssv-network.ts
+++ b/src/ssv-network.ts
@@ -1212,6 +1212,9 @@ export function handleOperatorRemoved(event: OperatorRemovedEvent): void {
   else {
     operator.operatorId = event.params.operatorId
     operator.removed = true
+    operator.feeIndex = operator.feeIndex.plus(event.block.number.minus(operator.feeIndexBlockNumber).times(operator.fee))
+    operator.feeIndexBlockNumber = event.block.number
+    operator.fee = new BigInt(0)
     operator.lastUpdateBlockNumber = event.block.number
     operator.validatorCount = new BigInt(0)
     operator.lastUpdateBlockTimestamp = event.block.timestamp


### PR DESCRIPTION
<img width="628" alt="image" src="https://github.com/user-attachments/assets/608ff9e9-8bdd-462d-97ac-5ce14f7742ca">

Locally on my cluster balance tool with the api url of my deployed subgraph with the changes, I see what looks to be the correct output as show in the screenshot.